### PR TITLE
Fix parmap deprecation warnings

### DIFF
--- a/pygmmis.py
+++ b/pygmmis.py
@@ -903,7 +903,7 @@ def _Estep(gmm, log_p, U, T_inv, log_S, data, covar=None, R=None, omega=None, ba
 
     k = 0
     for log_p[k], U[k], T_inv[k] in \
-    parmap.starmap(_Esum, zip(xrange(gmm.K), U), gmm, data, covar, R, cutoff, pool=pool, chunksize=chunksize):
+    parmap.starmap(_Esum, zip(xrange(gmm.K), U), gmm, data, covar, R, cutoff, pm_pool=pool, pm_chunksize=chunksize):
         log_S[U[k]] += np.exp(log_p[k]) # actually S, not logS
         H[U[k]] = 1
         k += 1
@@ -1008,7 +1008,7 @@ def _Mstep(gmm, U, log_p, T_inv, log_S, data, covar=None, R=None, p_bg=None, poo
     # however, there seem to be side effects or race conditions
     k = 0
     for A[k], M[k,:], C[k,:,:] in \
-    parmap.starmap(_Msums, zip(xrange(gmm.K), U, log_p, T_inv), gmm, data, R, log_S, pool=pool, chunksize=chunksize):
+    parmap.starmap(_Msums, zip(xrange(gmm.K), U, log_p, T_inv), gmm, data, R, log_S, pm_pool=pool, pm_chunksize=chunksize):
         k += 1
 
     if p_bg is not None:
@@ -1254,7 +1254,7 @@ def _findSNMComponents(gmm, U, log_p, log_S, N, pool=None, chunksize=1):
     k = 0
     A = gmm.amp * N
     for JS[k] in \
-    parmap.map(_JS, xrange(gmm.K), gmm, log_p, log_S, U, A, pool=pool, chunksize=chunksize):
+    parmap.map(_JS, xrange(gmm.K), gmm, log_p, log_S, U, A, pm_pool=pool, pm_chunksize=chunksize):
         k += 1
     """
     # get largest Eigenvalue, weighed by amplitude

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering :: Information Analysis"
     ],
-    install_requires=["numpy","scipy","parmap"]
+    install_requires=["numpy","scipy","parmap>=1.5.2"]
 )

--- a/tests/test_3D.py
+++ b/tests/test_3D.py
@@ -119,7 +119,7 @@ def max_posterior(gmm, U, coords, covar=None):
     H = np.zeros(len(coords), dtype="bool")
     k = 0
     for log_p[k], U[k], _ in \
-    parmap.starmap(pygmmis._Estep, zip(range(gmm.K), U), gmm, data, covar, None, pool=pool, pm_chunksize=chunksize):
+    parmap.starmap(pygmmis._Estep, zip(range(gmm.K), U), gmm, data, covar, None, pm_pool=pool, pm_chunksize=chunksize):
         log_S[U[k]] += np.exp(log_p[k]) # actually S, not logS
         H[U[k]] = 1
         k += 1


### PR DESCRIPTION
Since parmap 1.5.0, parmap allows to have keyword arguments passed to the function, besides positional arguments.

On that version I (parmap author) had to deprecate `pool` and `chunksize` arguments replacing them with `pm_pool` and `pm_chunksize` respectively.

parmap changelog:

https://github.com/zeehio/parmap/blob/2640864449afc94fad1e1af32b4ef43ac0a3f80c/ChangeLog#L16

This change was necessary to ensure parmap keyword arguments do not collide with your mapped function arguments. If your named arguments in your function don't start with `pm_` you are safe of any future argument I add to parmap (so it's just to avoid potential future problems) 

I hope it helps